### PR TITLE
fix(layout): Chat messages randomly disappear when scrolling

### DIFF
--- a/Chatto/Source/ChatController/Collaborators/ChatCollectionViewLayout.swift
+++ b/Chatto/Source/ChatController/Collaborators/ChatCollectionViewLayout.swift
@@ -115,7 +115,7 @@ open class ChatCollectionViewLayout: UICollectionViewLayout {
             if attribute.frame.intersects(rect) {
                 return .orderedSame
             }
-            if attribute.frame.minY > rect.maxY {
+            if attribute.frame.minY >= rect.maxY {
                 return .orderedDescending
             }
             return .orderedAscending


### PR DESCRIPTION
This bug has been present in the app from day 1. Though the team tried to identify the root cause of the issue in the past, nothing has been found to date.

The main obstacle has been to be able to reproduce the bug as one was happening randomly and was disappearing after the chat is updated with a new message.

After checking almost everything inside of the codebase, I started looking into the third-party dependencies, especially Chatto, as it is used as a backbone of our chat functionality.

Initially it didn't amount to much, right until I stumbled upon the custom layout calculations that are done inside of `ChatCollectionViewLayout`.

The devs behind Chatto did a pretty clever thing to improve performance of the above calculations: instead of linearly searching for the first item that intersects with the specified layout frame rect (with `O(n)` time complexity), they used the fact that the elements are sorted in an ascending order of their frames, implementing a binary search that tries to find any match and, after it is found, going in both directions until all the matching items are found. This simple thing improved the time complexity to `O(log n)`.

The devil, as it usually goes, is in the details.

To drive the binary search, 3 different checks were implemented:
- `attribute.frame.intersects(rect)` -> return `.orderedSame`
- `attribute.frame.minY > rect.maxY` -> return `.orderedDescending`
- otherwise return `.orderedAscending`

Initially I checked the normal chat behaviour: layout attributes seemed to be calculated in the right way, all is good.

After that I checked what's happening in one chat that was breaking: it turned out that the binary search couldn't find the match! Hence, the function was returning an empty array for the layout engine and the engine, in turn, was drawing the empty screen, just as it was instructed to.

So, the root cause was found, now is the time to find out what was exactly responsible for the bug.

According to Apple's documentation, `intersects` function returns `true if the two specified rectangles intersect; otherwise, false`. And, more importantly, it adds that `the first rectangle intersects the second if the intersection of the rectangles is not equal to the null rectangle`.

The above explanation tells us that if we have two rects `A` and `B` with the frames of `{x: 0, y: 0, width: 1, height: 1}` and `{x: 0, y: 1, width: 1, height: 1}`, despite `B` starting from the same point on the `y` axis where `A` ends, `A` and `B` won't be considered intersected because there is no overlap between them.

Because the items are not intersected, we need to decide to which part of the sorted array we need to move our binary search index next. Hence, we have a second statement that checks whether `minY` value of the attribute is greater than the rect's `maxY`. In our case these two points are identical, so this statement is `false` as well, hence we return .orderedAscending`.

And this is exactly why the bug was happening: by returning `.orderedAscending`, we go to the part of the array where all of the items just can't possibly intersect with the layout frame because the initial array is already sorted.

To fix the issue, we just need to change the second statement from `attribute.frame.minY > rect.maxY` to
`attribute.frame.minY >= rect.maxY`.

This way we will return `.orderedDescending` and go to the part of the array where we potentially can find the intersected items.